### PR TITLE
Add client env var for server URL

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+REACT_APP_SERVER_URL=http://localhost:5002

--- a/client/README.md
+++ b/client/README.md
@@ -14,6 +14,16 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
+## Environment Variables
+
+Create a `.env` file in the `client` directory to specify where the React app should send API and WebSocket requests during development.
+
+```
+REACT_APP_SERVER_URL=http://localhost:5002
+```
+
+When set, the frontend will use this URL instead of the current page origin.
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders without crashing', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // Initially the app shows a connecting message while the socket initializes
+  expect(screen.getByText(/connecting to server/i)).toBeInTheDocument();
 });

--- a/client/src/components/Game/JoinGameForm.js
+++ b/client/src/components/Game/JoinGameForm.js
@@ -223,7 +223,7 @@ export const JoinGameForm = ({ selectedGame, allGames, onRefreshGames }) => {
           console.log("Checking if bank exists for game:", selectedGameId);
 
           // Use direct fetch for players to avoid potential issues with the API service
-          const baseUrl = window.location.origin;
+          const baseUrl = process.env.REACT_APP_SERVER_URL || window.location.origin;
           const response = await fetch(
             `${baseUrl}/api/players/game/${selectedGameId}?_=${new Date().getTime()}`,
             {
@@ -338,7 +338,7 @@ export const JoinGameForm = ({ selectedGame, allGames, onRefreshGames }) => {
       });
 
       // Create player with direct fetch to avoid potential issues
-      const baseUrl = window.location.origin;
+      const baseUrl = process.env.REACT_APP_SERVER_URL || window.location.origin;
       const response = await fetch(`${baseUrl}/api/players`, {
         method: "POST",
         headers: {
@@ -419,7 +419,7 @@ export const JoinGameForm = ({ selectedGame, allGames, onRefreshGames }) => {
       console.log("Refreshing games with direct fetch...");
 
       // Get the base URL to ensure we hit the correct API endpoint
-      const baseUrl = window.location.origin;
+      const baseUrl = process.env.REACT_APP_SERVER_URL || window.location.origin;
       const apiUrl = `${baseUrl}/api/games`;
 
       console.log(`Making API request to: ${apiUrl}`);
@@ -660,7 +660,9 @@ export const JoinGameForm = ({ selectedGame, allGames, onRefreshGames }) => {
         <div>Selected game: {selectedGameId || "None"}</div>
         <div>Socket connected: {socket ? "Yes" : "No"}</div>
         <div>Bank exists: {bankExists ? "Yes" : "No"}</div>
-        <div>API URL: {window.location.origin}/api/games</div>
+        <div>
+          API URL: {(process.env.REACT_APP_SERVER_URL || window.location.origin)}/api/games
+        </div>
       </div>
     </Card>
   );

--- a/client/src/contexts/SocketContext.js
+++ b/client/src/contexts/SocketContext.js
@@ -13,14 +13,15 @@ export const SocketProvider = ({ children }) => {
 
   useEffect(() => {
     try {
-      // Connect to the server using relative URL with options
-      const newSocket = io(window.location.origin, {
+      // Connect to the server using env var when provided
+      const serverUrl = process.env.REACT_APP_SERVER_URL || window.location.origin;
+      const newSocket = io(serverUrl, {
         reconnectionAttempts: 5,
         timeout: 10000,
         transports: ["websocket", "polling"], // Try websocket first, fallback to polling
       });
 
-      console.log("Attempting socket connection to:", window.location.origin);
+      console.log("Attempting socket connection to:", serverUrl);
 
       // Set up event handlers
       newSocket.on("connect_error", (err) => {

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,9 +1,14 @@
 // client/src/services/api.js
 import axios from "axios";
 
+// Determine base API URL - use env var in development if provided
+const baseURL = process.env.REACT_APP_SERVER_URL
+  ? `${process.env.REACT_APP_SERVER_URL}/api`
+  : "/api";
+
 // Create an axios instance with default configuration
 const api = axios.create({
-  baseURL: "/api",
+  baseURL,
   headers: {
     "Cache-Control": "no-cache, no-store, must-revalidate",
     Pragma: "no-cache",


### PR DESCRIPTION
## Summary
- configure React app with `.env` file specifying `REACT_APP_SERVER_URL`
- use this variable for WebSocket and API connections
- adjust JoinGameForm fetch requests
- document the variable in `client/README.md`
- update failing test

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6842801c50b083248717c724f5e2d246