### PR TITLE
Remove unused api import

### DIFF
--- a/client/src/components/Game/JoinGameForm.js
+++ b/client/src/components/Game/JoinGameForm.js
@@ -8,7 +8,6 @@ import { Input } from "../UI/Input";
 import { Select } from "../UI/Select";
 import { Button } from "../UI/Button";
 import { Card } from "../Layout/Card";
-import * as api from "../../services/api";
 
 const FormTitle = styled.h2`
   font-size: ${({ theme }) => theme.typography.fontSizes.xlarge};


### PR DESCRIPTION
## Summary
- remove an unused import from JoinGameForm

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842930239008324a08248e08ec66a8d